### PR TITLE
Bugfix: Cambiar URL WebClient

### DIFF
--- a/accounts/src/main/resources/application.properties
+++ b/accounts/src/main/resources/application.properties
@@ -19,7 +19,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 # spring.sql.init.schema-locations=classpath:schema.sql
 # spring.sql.init.data-locations=classpath:data.sql
 
-clientes.service.url=http://localhost:8080
+clientes.service.url=http://clients:8080
 
 
 


### PR DESCRIPTION
- Se cambia la URL del WebClient para que apunte al microservicio de clientes cuando estén levantados los contenedores.